### PR TITLE
add waiting handler code

### DIFF
--- a/src/backend/functions/orchestrator/index.js
+++ b/src/backend/functions/orchestrator/index.js
@@ -1,0 +1,10 @@
+const AWS = require('aws-sdk');
+const ecs = new AWS.ECS({region: process.env.AWS_REGION});
+const ddb = new AWS.DynamoDB.DocumentClient({region: process.env.AWS_REGION});
+
+const handler = require('./lib');
+
+exports.handler = function (event, context) {
+    // need to invoke lazily or else can't mock handler
+    return handler(ecs, ddb, process.env)(event, context);
+};

--- a/src/backend/functions/orchestrator/lib/index.js
+++ b/src/backend/functions/orchestrator/lib/index.js
@@ -1,0 +1,86 @@
+const AWS = require('aws-sdk');
+const R = require('ramda');
+const converter = AWS.DynamoDB.Converter;
+
+// snakeToCamel :: String -> String
+const snakeToCamel = R.replace(/([_][a-z])/g, R.compose(R.replace('_', ''), R.toUpper));
+
+function noop() {}
+
+// convertEnvVars :: {k: v} -> {k: v}
+const convertEnvVars = R.pipe(
+    R.toPairs,
+    R.map(R.adjust(0, R.compose(snakeToCamel, R.toLower))),
+    R.fromPairs,
+    R.evolve({subnets: subnets => [...subnets.split(',').map(R.trim)]})
+);
+
+// startTranscription :: AWS.ECS -> AWS.DDB -> Promise {k: v}
+const startTranscription = R.curry((ecs, ddb, options) => {
+   const params = {
+      taskDefinition: options.taskName,
+      cluster: options.cluster,
+      launchType: 'FARGATE',
+      networkConfiguration: {
+         awsvpcConfiguration: {
+            subnets: options.subnets,
+            assignPublicIp: 'DISABLED'
+         }
+      },
+      overrides: {
+         containerOverrides: [
+            {
+               name: 'transcriber',
+               environment: [
+                  {
+                     name: 'MEDIA_URL',
+                     value: options.mediaUrl
+                  }
+               ]
+            }
+         ]
+      }
+   };
+
+   return ecs.runTask(params)
+       .promise()
+       .then(({tasks}) => {
+         return ddb.put({
+            TableName: options.tasksTableName,
+            Item: {
+               MediaUrl: options.mediaUrl,
+               TaskArn: tasks[0].taskArn,
+               TaskStatus: 'INITIALIZING'
+            }
+         }).promise()
+   });
+});
+
+// waiting :: AWS.ECS -> AWS.DynamoDB -> {k: v} -> String -> Promise {k:v}
+const waiting = R.curry((ecs, ddb, env, mediaUrl) =>
+    R.compose(startTranscription(ecs, ddb), R.mergeRight({mediaUrl}), convertEnvVars)(env)
+);
+
+function terminating(ecs, ddb) {}
+
+function error(ecs, ddb) {}
+
+// handler :: AWS.ECS -> AWS.DynamoDB -> {k: v} -> ({k: v} -> {k: v} -> Promise {k: v})
+module.exports = (ecs, ddb, env) => {
+   const handlers = {
+      WAITING: waiting(ecs, ddb),
+      INITIALIZING: noop,
+      PROCESSING: noop,
+      TERMINATING: terminating,
+      ERROR: error
+   };
+
+   return (event, context) => {
+      const promises = R.map(record => {
+         const {TaskStatus, MediaUrl} = converter.unmarshall(R.path(['dynamodb', 'NewImage'], record));
+         return handlers[TaskStatus](env, MediaUrl);
+      }, event.Records);
+
+      return Promise.all(promises);
+   };
+};

--- a/src/backend/functions/orchestrator/package.json
+++ b/src/backend/functions/orchestrator/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "orchestrator",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Orchestrator lambda for managing transcription tasks",
+  "main": "lib/index.js",
+  "scripts": {
+    "test": "mocha"
+  },
+  "dependencies": {
+    "aws-sdk": "2.369.0",
+    "ramda": "0.26.1"
+  },
+  "devDependencies": {
+    "chai": "4.2.0",
+    "mocha": "6.2.0",
+    "mocked-env": "^1.3.1",
+    "rewire": "4.0.1",
+    "sinon": "7.3.2"
+  }
+}

--- a/src/backend/functions/orchestrator/test/fixtures/dynamo_update.json
+++ b/src/backend/functions/orchestrator/test/fixtures/dynamo_update.json
@@ -1,0 +1,90 @@
+{
+  "Records": [
+    {
+      "eventID": "1",
+      "eventVersion": "1.0",
+      "dynamodb": {
+        "Keys": {
+          "MediaUrl": {
+            "S": "https://foo.bar/foo"
+          }
+        },
+        "NewImage": {
+          "MediaUrl": {
+            "S": "New item!"
+          },
+          "TaskStatus": {
+            "S": "WAITING"
+          }
+        },
+        "StreamViewType": "NEW_AND_OLD_IMAGES",
+        "SequenceNumber": "111",
+        "SizeBytes": 26
+      },
+      "awsRegion": "eu-west-1",
+      "eventName": "INSERT",
+      "eventSourceARN": "arn:aws:dynamodb:eu-west-1:account-id:table/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
+      "eventSource": "aws:dynamodb"
+    },
+    {
+      "eventID": "2",
+      "eventVersion": "1.0",
+      "dynamodb": {
+        "OldImage": {
+          "MediaUrl": {
+            "S": "https://foo.bar/bar"
+          },
+          "TaskStatus": {
+            "S": "TERMINATING"
+          }
+        },
+        "SequenceNumber": "222",
+        "Keys": {
+          "MediaUrl": {
+            "S": "https://foo.bar/bar"
+          }
+        },
+        "SizeBytes": 59,
+        "NewImage": {
+          "MediaUrl": {
+            "S": "This item has changed"
+          },
+          "TaskStatus": {
+            "S": "101"
+          }
+        },
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "awsRegion": "eu-west-1",
+      "eventName": "MODIFY",
+      "eventSourceARN": "arn:aws:dynamodb:eu-west-1:account-id:table/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
+      "eventSource": "aws:dynamodb"
+    },
+    {
+      "eventID": "3",
+      "eventVersion": "1.0",
+      "dynamodb": {
+        "Keys": {
+          "MediaUrl": {
+            "S": "https://foo.bar/baz"
+          }
+        },
+        "SizeBytes": 38,
+        "SequenceNumber": "333",
+        "OldImage": {
+          "MediaUrl": {
+            "S": "https://foo.bar/baz"
+          },
+          "TaskStatus": {
+            "S": "ERROR"
+          }
+        },
+        "StreamViewType": "NEW_AND_OLD_IMAGES"
+      },
+      "awsRegion": "eu-west-1",
+      "eventName": "REMOVE",
+      "eventSourceARN": "arn:aws:dynamodb:eu-west-1:account-id:table/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
+      "eventSource": "aws:dynamodb"
+    }
+  ]
+}

--- a/src/backend/functions/orchestrator/test/fixtures/waiting_ddb_event.json
+++ b/src/backend/functions/orchestrator/test/fixtures/waiting_ddb_event.json
@@ -1,0 +1,30 @@
+{
+  "Records": [
+    {
+      "eventID": "1",
+      "eventVersion": "1.0",
+      "dynamodb": {
+        "Keys": {
+          "MediaUrl": {
+            "S": "https://foo.bar/foo"
+          }
+        },
+        "NewImage": {
+          "MediaUrl": {
+            "S": "https://foo.bar/foo"
+          },
+          "TaskStatus": {
+            "S": "WAITING"
+          }
+        },
+        "StreamViewType": "NEW_AND_OLD_IMAGES",
+        "SequenceNumber": "111",
+        "SizeBytes": 26
+      },
+      "awsRegion": "eu-west-1",
+      "eventName": "INSERT",
+      "eventSourceARN": "arn:aws:dynamodb:eu-west-1:account-id:table/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
+      "eventSource": "aws:dynamodb"
+    }
+  ]
+}

--- a/src/backend/functions/orchestrator/test/index.js
+++ b/src/backend/functions/orchestrator/test/index.js
@@ -1,0 +1,41 @@
+const {assert} = require('chai');
+const mockedEnv = require('mocked-env');
+const rewire = require('rewire');
+const sinon = require('sinon');
+
+const index = rewire('../index');
+
+describe('index.js', () => {
+
+    describe('handler', () => {
+        let restore;
+
+        before(() => {
+            restore = mockedEnv({
+                AWS_REGION: 'eu-west-1',
+                TASKS_TABLE_NAME: 'MediaAnalysisTasks',
+                CLUSTER: 'MyCluster',
+                TASK_NAME: 'transcriber',
+                SUBNETS: 'subnet1, subnet2',
+            }, { clear: true })
+        });
+
+
+        const handlerStub = sinon.stub().returns(() => {});
+        const revertHandler = index.__set__('handler', handlerStub);
+
+        it('should call the handler with dependencies', () => {
+            index.handler({}, {});
+            sinon.assert.calledWith(handlerStub, index.__get__('ecs'), index.__get__('ddb'), {
+                AWS_REGION: 'eu-west-1',
+                TASKS_TABLE_NAME: 'MediaAnalysisTasks',
+                CLUSTER: 'MyCluster',
+                TASK_NAME: 'transcriber',
+                SUBNETS: 'subnet1, subnet2',
+            });
+            revertHandler();
+        });
+
+        after(() => restore())
+    });
+});

--- a/src/backend/functions/orchestrator/test/lib/index.js
+++ b/src/backend/functions/orchestrator/test/lib/index.js
@@ -1,0 +1,110 @@
+const {assert} = require('chai');
+const rewire = require('rewire');
+const sinon = require('sinon');
+
+const index = rewire('../../lib');
+
+const waitingEvent = require('../fixtures/waiting_ddb_event.json');
+
+describe('lib/index.js', () => {
+
+    describe('snakeToCamel', () => {
+        const snakeToCamel = index.__get__('snakeToCamel');
+
+        it('should convert snake case to camel case', () => {
+            assert.equal(snakeToCamel(''), '');
+            assert.equal(snakeToCamel('not'), 'not');
+            assert.equal(snakeToCamel('my_method'), 'myMethod');
+            assert.equal(snakeToCamel('my_very_long_method'), 'myVeryLongMethod');
+        });
+    });
+
+    describe('convertEnvVars', () => {
+        const convertEnvVars = index.__get__('convertEnvVars');
+
+        it('should convert environment variables to parameters waiting function options', () => {
+            const input = {
+                TASKS_TABLE_NAME: 'MediaAnalysisTasks',
+                CLUSTER: 'MyCluster',
+                TASK_NAME: 'transcriber',
+                SUBNETS: 'subnet1, subnet2',
+            };
+
+            const expected = {
+                tasksTableName: 'MediaAnalysisTasks',
+                cluster: 'MyCluster',
+                taskName: 'transcriber',
+                subnets: ['subnet1', 'subnet2']
+            };
+
+            const actual = convertEnvVars(input);
+
+            assert.deepEqual(actual, expected);
+        });
+
+    });
+
+    describe('handler', () => {
+
+        it('should start transcription when WAITING state received', () => {
+            const runTaskStub = sinon.stub().returns({
+                promise: () => Promise.resolve({
+                    tasks: [{
+                        taskArn: 'taskArn'
+                    }]
+                })
+            });
+
+            const putStub = sinon.stub().returns({promise: () => Promise.resolve('yay')});
+
+            const expectedTaskParams = {
+                taskDefinition: 'transcriber',
+                cluster:'MyCluster',
+                launchType: 'FARGATE',
+                networkConfiguration: {
+                    awsvpcConfiguration: {
+                        subnets: ['subnet1', 'subnet2'],
+                        assignPublicIp: 'DISABLED'
+                    }
+                },
+                overrides: {
+                    containerOverrides: [
+                        {
+                            name: 'transcriber',
+                            environment: [
+                                {
+                                    name: 'MEDIA_URL',
+                                    value: 'https://foo.bar/foo'
+                                }
+                            ]
+                        }
+                    ]
+                }
+            };
+
+            const expectedPutParams = {
+                TableName: 'MediaAnalysisTasks',
+                Item: {
+                    MediaUrl: 'https://foo.bar/foo',
+                    TaskArn: 'taskArn',
+                    TaskStatus: 'INITIALIZING'
+                }
+            };
+
+            const handler = index({runTask: runTaskStub}, {put: putStub}, {
+                TASKS_TABLE_NAME: 'MediaAnalysisTasks',
+                CLUSTER: 'MyCluster',
+                TASK_NAME: 'transcriber',
+                SUBNETS: 'subnet1, subnet2',
+            });
+
+            return handler(waitingEvent, {})
+                .then(() => {
+                    sinon.assert.calledWith(runTaskStub, expectedTaskParams);
+                    sinon.assert.calledWith(putStub, expectedPutParams);
+                })
+        });
+
+    });
+
+});


### PR DESCRIPTION
*Description of changes:*

This PR creates the structure for the lambda handler that will orchestrate the creation of the transcription containers. This is an MVP and only codes the happy path for the handling the WAITING state. The subsequent states and error handling will be added in separate PRs.

If you're unfamiliar with the Ramda library it is similar to Lodash but far better suited to functional programming, the docs are [here](https://ramdajs.com/0.26.1/docs/).