### PR TITLE
Add TERMINATING and TERMINATION steps

### DIFF
--- a/src/backend/functions/orchestrator/lib/index.js
+++ b/src/backend/functions/orchestrator/lib/index.js
@@ -85,18 +85,12 @@ function createUpdateParams({tasksTableName, mediaUrl, taskArn}) {
 
 // waiting :: AWS.ECS -> AWS.DynamoDB -> {k: v} -> String -> Promise {k:v}
 const waiting = R.curry((ecs, updateItem) =>
-    handle(composeP(updateItem, createUpdateParams, startTranscription(ecs)), image => {
-       const {MediaUrl: mediaUrl} = image;
-       return {mediaUrl};
-    })
+    handle(composeP(updateItem, createUpdateParams, startTranscription(ecs)), ({MediaUrl: mediaUrl}) => ({mediaUrl}))
 );
 
 // terminating :: AWS.ECS -> {k: v} -> String -> Promise {k:v}
 const terminating = R.curry(ecs =>
-   handle(stopTranscription(ecs), image => {
-      const {TaskArn: task} = image;
-      return {task};
-   })
+   handle(stopTranscription(ecs), ({TaskArn: task}) => ({task}))
 );
 
 function createDeleteParams({mediaUrl, tasksTableName}) {
@@ -110,10 +104,7 @@ function createDeleteParams({mediaUrl, tasksTableName}) {
 
 // terminated :: ({k:v} -> Promise {k: v}) -> {k: v} -> String -> Promise {k:v}
 const terminated = R.curry(deleteItem =>
-    handle(o(deleteItem, createDeleteParams), image => {
-       const {MediaUrl: mediaUrl} = image;
-       return {mediaUrl};
-    })
+   handle(o(deleteItem, createDeleteParams), ({MediaUrl: mediaUrl}) => ({mediaUrl}))
 );
 
 function error(ecs, ddb) {}

--- a/src/backend/functions/orchestrator/test/fixtures/terminated_ddb_event.json
+++ b/src/backend/functions/orchestrator/test/fixtures/terminated_ddb_event.json
@@ -1,0 +1,33 @@
+{
+  "Records": [
+    {
+      "eventID": "1",
+      "eventVersion": "1.0",
+      "dynamodb": {
+        "Keys": {
+          "MediaUrl": {
+            "S": "https://foo.bar/foo"
+          }
+        },
+        "NewImage": {
+          "MediaUrl": {
+            "S": "https://foo.bar/foo"
+          },
+          "TaskStatus": {
+            "S": "TERMINATED"
+          },
+          "TaskArn": {
+            "S": "taskArn"
+          }
+        },
+        "StreamViewType": "NEW_IMAGES",
+        "SequenceNumber": "111",
+        "SizeBytes": 26
+      },
+      "awsRegion": "eu-west-1",
+      "eventName": "UPDATE",
+      "eventSourceARN": "arn:aws:dynamodb:eu-west-1:account-id:table/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
+      "eventSource": "aws:dynamodb"
+    }
+  ]
+}

--- a/src/backend/functions/orchestrator/test/fixtures/terminating_ddb_event.json
+++ b/src/backend/functions/orchestrator/test/fixtures/terminating_ddb_event.json
@@ -1,0 +1,33 @@
+{
+  "Records": [
+    {
+      "eventID": "1",
+      "eventVersion": "1.0",
+      "dynamodb": {
+        "Keys": {
+          "MediaUrl": {
+            "S": "https://foo.bar/foo"
+          }
+        },
+        "NewImage": {
+          "MediaUrl": {
+            "S": "https://foo.bar/foo"
+          },
+          "TaskStatus": {
+            "S": "TERMINATING"
+          },
+          "TaskArn": {
+            "S": "taskArn"
+          }
+        },
+        "StreamViewType": "NEW_IMAGES",
+        "SequenceNumber": "111",
+        "SizeBytes": 26
+      },
+      "awsRegion": "eu-west-1",
+      "eventName": "UPDATE",
+      "eventSourceARN": "arn:aws:dynamodb:eu-west-1:account-id:table/ExampleTableWithStream/stream/2015-06-27T00:48:05.899",
+      "eventSource": "aws:dynamodb"
+    }
+  ]
+}

--- a/src/backend/transcriber/src/main/java/com/amazonaws/transcriber/App.java
+++ b/src/backend/transcriber/src/main/java/com/amazonaws/transcriber/App.java
@@ -67,7 +67,6 @@ public class App {
             promise.get();
         } catch (InterruptedException | ExecutionException ex) {
             logger.error("Transcription stopped...", ex);
-            lcp.transcriptionTerminating();
         }
     }
 
@@ -78,8 +77,8 @@ public class App {
             logger.info("Stopping ffmpeg encoding.");
             encoder.stop();
 
-            logger.info("Persisting lifecycle stage TERMINATING in DynamoDb...");
-            lcp.transcriptionTerminating();
+            logger.info("Persisting lifecycle stage TERMINATED in DynamoDb...");
+            lcp.transcriptionTerminated();
 
             //shutdown log4j2
             if( LogManager.getContext() instanceof LoggerContext ) {

--- a/src/backend/transcriber/src/main/java/com/amazonaws/transcriber/App.java
+++ b/src/backend/transcriber/src/main/java/com/amazonaws/transcriber/App.java
@@ -31,6 +31,7 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -39,6 +40,7 @@ public class App {
     private static final Logger logger = LogManager.getLogger(App.class);
 
     private static TranscriberConfig config = TranscriberConfig.getInstance();
+    private static String error;
 
     public static void main(String... args) {
         String input = config.mediaUrl();
@@ -53,7 +55,7 @@ public class App {
             config.mediaSampleRate(), config.vocabularyName().orElse(""));
         Encoder encoder = new Encoder(config.ffmpegPath(), "s16le", input);
 
-        addShutdownHook(transcriber, encoder, lcp);
+        addShutdownHook(lcp);
 
         InputStream mediaStream = encoder.start();
         try {
@@ -65,20 +67,30 @@ public class App {
             // storing the promises in an array and then using an infinite loop to keep the main
             // thread alive but as we only have one video per container this is not necessary
             promise.get();
-        } catch (InterruptedException | ExecutionException ex) {
-            logger.error("Transcription stopped...", ex);
+        } catch (InterruptedException ie) {
+            logger.info("Transcription thread stopped...");
+        } catch (ExecutionException ex) {
+            logger.error("Transcription errored...", ex);
+            error = ex.getMessage();
+        } finally {
+            logger.info("Stopping transcription.");
+            transcriber.stop();
+
+            logger.info("Stopping ffmpeg encoding.");
+            encoder.stop();
         }
     }
 
-    private static void addShutdownHook(Transcriber transcriber, Encoder encoder, LifecycleInfoPersister lcp) {
+    private static void addShutdownHook(LifecycleInfoPersister lcp) {
         Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            logger.info("Stopping transcription.");
-            transcriber.stop();
-            logger.info("Stopping ffmpeg encoding.");
-            encoder.stop();
-
-            logger.info("Persisting lifecycle stage TERMINATED in DynamoDb...");
-            lcp.transcriptionTerminated();
+            if(error == null) {
+                logger.info("Persisting lifecycle stage TERMINATED in DynamoDb...");
+                lcp.transcriptionTerminated();
+            }
+            else {
+                logger.info("Persisting lifecycle stage ERROR in DynamoDb...");
+                lcp.transcriptionErrored(error);
+            }
 
             //shutdown log4j2
             if( LogManager.getContext() instanceof LoggerContext ) {

--- a/src/backend/transcriber/src/main/java/com/amazonaws/transcriber/LifecycleInfoPersister.java
+++ b/src/backend/transcriber/src/main/java/com/amazonaws/transcriber/LifecycleInfoPersister.java
@@ -26,8 +26,8 @@ class LifecycleInfoPersister {
         writeTranscriptionStatus("PROCESSING");
     }
 
-    void transcriptionTerminating() {
-        writeTranscriptionStatus("TERMINATING");
+    void transcriptionTerminated() {
+        writeTranscriptionStatus("TERMINATED");
     }
 
     private void writeTranscriptionStatus(String status) {


### PR DESCRIPTION
*Description of changes:*

I've split the termination step in two so that the container controls when it says it has finished processing. The new flow is `TERMINATING -> Stop task -> TERMINATED -> Delete DynamoDb item`. I've also factored out the logic from the three state handlers are now based on a single generic function that takes higher order functions to customise the behaviour.

