### PR TITLE
Make media description optional in request template

### DIFF
--- a/src/cfn/template.yaml
+++ b/src/cfn/template.yaml
@@ -971,17 +971,22 @@ Resources:
                         }
                 requestTemplates:
                   application/json: !Sub |
+                    #set($inputRoot = $input.path('$'))
+                    #set($mediaTitle = $inputRoot.mediaTitle)
+                    #set($mediaDescription = $inputRoot.mediaDescription)
                     {
                       "TableName": "${TasksDynamoTable}",
                       "Item": {
+                        #if("$mediaDescription" != "")
                         "MediaDescription": {
-                          "S": $input.json('$.mediaDescription')
+                          "S": "$mediaDescription"
                         },
+                        #end
                         "MediaUrl": {
                           "S": "$util.urlDecode($input.params('mediaUrl'))"
                         },
                         "MediaTitle": {
-                          "S": $input.json('$.mediaTitle')
+                          "S": "$mediaTitle"
                         },
                         "TaskStatus": {
                           "S": "WAITING"


### PR DESCRIPTION
*Issue #, if available:* n/a

*Description of changes:*
* makes the media description an optional field through VTL check. covers not provided and empty string scenarios

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
