### PR TITLE
 tag transcriber image as latest

### DIFF
--- a/src/cfn/template.yaml
+++ b/src/cfn/template.yaml
@@ -516,8 +516,7 @@ Resources:
             pre_build:
               commands:
                 - $(aws ecr get-login --no-include-email)
-                - TAG="$(echo $CODEBUILD_RESOLVED_SOURCE_VERSION | head -c 8)"
-                - IMAGE_URI="${REPOSITORY_URI}:${TAG}"
+                - IMAGE_URI="${REPOSITORY_URI}"
             build:
               commands:
                 - docker build --tag "$IMAGE_URI" .


### PR DESCRIPTION
For a fresh deploy, CodeBuild currently registers the transcriber image with a tag based on the `CODEBUILD_RESOLVED_SOURCE_VERSION` which means the latest tag doesn't exist and the transcriber containers can't be launched. This PR fixes this by tagging the image as `latest` (the default) instead which is a predictable image tag reference for the `TransciberTaskDefinition` resource