### PR TITLE
When resolved url != mediaUrl, dynamo writes fail

### DIFF
--- a/src/backend/transcriber/src/main/java/com/amazonaws/transcriber/App.java
+++ b/src/backend/transcriber/src/main/java/com/amazonaws/transcriber/App.java
@@ -44,14 +44,15 @@ public class App {
 
     public static void main(String... args) {
         String input = config.mediaUrl();
-        LifecycleInfoPersister lcp  = new LifecycleInfoPersister(input);
-        logger.info("Input is {}", input);
+        String resolved = input;
+        LifecycleInfoPersister lcp  = new LifecycleInfoPersister(resolved);
+        logger.info("Input is {}", resolved);
         if (input.startsWith("https://www.youtube.com/")) {
-            input = getYouTubeUrl(config.youtubeDlPath(), input);
-            logger.info("YouTube input is %s", input);
+            resolved = getYouTubeUrl(config.youtubeDlPath(), input);
+            logger.info("YouTube input is %s", resolved);
         }
 
-        Encoder encoder = new Encoder(config.ffmpegPath(), "s16le", input);
+        Encoder encoder = new Encoder(config.ffmpegPath(), "s16le", resolved);
         Transcriber transcriber = new Transcriber(input, LanguageCode.EN_US, MediaEncoding.PCM,
             config.mediaSampleRate(), config.vocabularyName().orElse(""));
 


### PR DESCRIPTION
In this way, the transcription should work but the dynamo should write with the proper key.
I tested this locally with a yt video and it works fine.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
