### PR TITLE
don't start task in error handler

### DIFF
--- a/src/backend/functions/orchestrator/package.json
+++ b/src/backend/functions/orchestrator/package.json
@@ -8,14 +8,13 @@
     "build": "rm -rf dist && rsync -avz . dist/ --exclude 'node_modules' --exclude 'test'",
     "test": "mocha --recursive"
   },
-  "dependencies": {
-    "aws-sdk": "2.369.0",
-    "ramda": "0.26.1"
-  },
+  "dependencies": {},
   "devDependencies": {
+    "aws-sdk": "2.369.0",
     "chai": "4.2.0",
     "mocha": "6.2.0",
-    "mocked-env": "^1.3.1",
+    "mocked-env": "1.3.1",
+    "ramda": "0.26.1",
     "rewire": "4.0.1",
     "sinon": "7.3.2"
   }

--- a/src/backend/transcriber/transcriber.iml
+++ b/src/backend/transcriber/transcriber.iml
@@ -12,6 +12,7 @@
     </content>
     <orderEntry type="jdk" jdkName="1.8" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.25" level="project" />
     <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-api:2.12.1" level="project" />
     <orderEntry type="library" name="Maven: org.apache.logging.log4j:log4j-core:2.12.1" level="project" />
     <orderEntry type="library" name="Maven: org.apache.commons:commons-lang3:3.8" level="project" />

--- a/src/cfn/template.yaml
+++ b/src/cfn/template.yaml
@@ -12,7 +12,7 @@ Globals:
     Runtime: nodejs10.x
     Environment:
       Variables:
-        VERSION: '0.10'
+        VERSION: '0.11'
 
 Parameters:
 


### PR DESCRIPTION
*Description of changes:*

For some reason I was starting a new task in the error handler rather than just transitioning to the `WAITING` state and allowing the other handlers to take over.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
