### PR TITLE
remove catch at end of lambda handler

### DIFF
--- a/src/cfn/template.yaml
+++ b/src/cfn/template.yaml
@@ -13,7 +13,7 @@ Globals:
     Runtime: nodejs10.x
     Environment:
       Variables:
-        VERSION: '1.0'
+        VERSION: '1.1'
 
 Parameters:
 


### PR DESCRIPTION
*Description of changes:*

I forgot to remove the catch at the end of of the promise chain in the lambda handler, which means it would swallow all errors. I also tidied up some of the type signatures.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
