### PR TITLE
Upgrade deprecated runtime nodejs8.10

### DIFF
--- a/src/cfn/template.yaml
+++ b/src/cfn/template.yaml
@@ -271,8 +271,8 @@ Resources:
       Description: Latest confirmed compatible AWS SDK
       ContentUri: ../backend/functions/layers/aws_sdk/
       CompatibleRuntimes:
-        - nodejs8.10
         - nodejs10.x
+        - nodejs12.x
 
   FPLayer:
     Type: AWS::Serverless::LayerVersion
@@ -281,8 +281,8 @@ Resources:
       Description: Layer containing functional programming libs
       ContentUri: ../backend/functions/layers/fp/
       CompatibleRuntimes:
-        - nodejs8.10
         - nodejs10.x
+        - nodejs12.x
 
   Orchestrator:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
CloudFormation templates in amazon-transcribe-news-media-analysis have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs8.10). The affected templates have been updated to a supported runtime (nodejs10.x).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.