### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/src/cfn/template.yaml
+++ b/src/cfn/template.yaml
@@ -10,7 +10,7 @@ Globals:
       AllowHeaders: "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'"
       AllowOrigin: "'*'"
   Function:
-    Runtime: nodejs10.x
+    Runtime: nodejs14.x
     Environment:
       Variables:
         VERSION: '1.6'
@@ -271,7 +271,7 @@ Resources:
       Description: Latest confirmed compatible AWS SDK
       ContentUri: ../backend/functions/layers/aws_sdk/
       CompatibleRuntimes:
-        - nodejs10.x
+        - nodejs14.x
         - nodejs12.x
 
   FPLayer:
@@ -281,7 +281,7 @@ Resources:
       Description: Layer containing functional programming libs
       ContentUri: ../backend/functions/layers/fp/
       CompatibleRuntimes:
-        - nodejs10.x
+        - nodejs14.x
         - nodejs12.x
 
   Orchestrator:


### PR DESCRIPTION
CloudFormation templates in amazon-transcribe-news-media-analysis have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.